### PR TITLE
Update README

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,6 @@ tab_width = 2
 
 [COMMIT_EDITMSG]
 max_line_length = 72
+
+[*.md]
+max_line_length = 80

--- a/README.md
+++ b/README.md
@@ -1,30 +1,76 @@
 # PHPDepend
-PHPStan plugin to create a dependency related visualisations.
 
-## Dependency Matrix
+A tool to create dependency related visualizations based on raw-data created via
+the [callmap plugin](https://github.com/phpdepend/callmap) for PHPStan.
 
-Create a dependency matrix to see what part of your application is depending on what other parts.
-
-```bash
-./bin/phpdepend matrix <path/to/callmap.json>
-```
-
-![Example output](dependency-matrix.png)
-
-## Full chain:
+To create the raw-data required you will need to run these commands:
 
 ```bash
 # Install PHPStan
 composer require --dev phpstan/phpstan
-# Install plugin
-composer require --dev phpdepend/callmap dev-main
+# Install callmap-plugin
+composer require --dev phpdepend/callmap
 # parse the sources and generate the callmap.json file
 ./vendor/bin/phpstan analyse -c vendor/phpdepend/callmap/callmap.neon [path/to/your/sources]
-# Install the callmap cli
-composer require phpdepend/phpdepend@dev-main
-# Convert the callmap.json file into a matrix.html file
-./bin/phpdepend matrix callmap.json
 ```
+
+This will create a file `callmap.json` in your current working directory which
+is the base
+for all following commands.
+
+## Installation
+
+PHPDepend can be installed via
+
+### composer
+
+Installation via composer is straightforward
+
+```bash
+composer require --dev phpdepend/phpdepend
+```
+
+This will make PHPDepend available via `./vendor/bin/phpdepend`
+
+### phive
+
+Installation via phive is also possible. This will especially check the
+signature matches
+so that you can trust that the downloaded PHAR is the one that was signed during
+the build.
+
+```bash
+phive install phpdepend/phpdepend
+```
+
+This will make PHPDepend available via `./tools/phpdepend`
+
+### PHAR-Download
+
+You can also download the latest PHAR file from the relase-page.
+
+```bash
+curl -LO https://api.getlatestassets/github/phpdepend/phpdepend/phpdepend.phar
+chmod a+x phpdepend.phar
+```
+
+This will make PHPDepend available via `./phpdepend.phar`
+
+## Dependency Matrix
+
+Create a dependency matrix to see what part of your application is depending on
+what other parts.
+
+### Usage:
+
+```bash
+phpdepend matrix <path/to/callmap.json>
+```
+
+This will create a HTML-file in the current folder whose content looks like
+this:
+
+![Example output](dependency-matrix.png)
 
 ## Dependency Graph
 
@@ -33,36 +79,23 @@ Graph generates a PlantUML file from a CallMap-JSON file.
 
 ### Usage
 
-After you have created a callmap-JSON file (for example via the stella-maris/callmap
-plugin for PHPStan) you can create the PlantUML file via this command:
-
 ```bash
-./bin/phpdepend graph <path/to/callmap.json>
+phpdepend graph <path/to/callmap.json>
 ```
 
-This will generate a PlantUML file in the current directory names `callmap.plantuml`.
+This will generate a PlantUML file `callmap.plantuml` in the current directory.
 
 You can use this file to generate a PNG os SVG using a PlantUML renderer like at
 http://www.plantuml.com/plantuml/uml/
 
-For the [`phpdepend/callmap`](https://github.com/phpdepend/callmap) plugin that should generate something like this:
-
-![Example output](callmap.png)
-
-
-## Full chain:
+Alternatively you can use the plantuml-docker image like this:
 
 ```bash
-# Install PHPStan
-composer require --dev phpstan/phpstan 1.11.x-dev
-# Install plugin
-composer require --dev phpdepend/callmap dev-main
-# parse the sources and generate the callmap.json file
-./vendor/bin/phpstan analyse -c vendor/phpdepend/callmap/callmap.neon [path/to/your/sources]
-# Install the callmap cli
-composer require phpdepend/phpdepend@dev-main
-# Convert the callmap.json file into a callmap.plantuml file
-./bin/phpdepend graph callmap.json
 # Render a PNG file from the callmap.plantuml file
 docker run -v "$(pwd):/app" -w "/app" ghcr.io/plantuml/plantuml callmap.plantuml
 ```
+
+For the [`phpdepend/callmap`](https://github.com/phpdepend/callmap) plugin that should generate something like
+this:
+
+![Example output](callmap.png)


### PR DESCRIPTION
This separates the tool installation and the tool usage into separate parts of the readme so that we do not have to repeat the same instructions over and over again but can keep the usage-sections of the different commands that the CLI provides short and conscise